### PR TITLE
Uses https if environment is "production" in .env

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,6 +23,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        // Force https if using for production
+        if($this->app->environment('production')) {
+            \URL::forceScheme('https');
+        }
     }
 }


### PR DESCRIPTION
Forces the use of https if the environment is set to "production" in the .env file. This fixes an issue with Laravel conflicting with my website's https certificate.